### PR TITLE
Fixed missing View facade

### DIFF
--- a/src/KraftHaus/Bauhaus/Field/FileField.php
+++ b/src/KraftHaus/Bauhaus/Field/FileField.php
@@ -14,6 +14,8 @@ namespace KraftHaus\Bauhaus\Field;
 use KraftHaus\Bauhaus\Field\BaseField;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\View;
+
 
 /**
  * Class FileField
@@ -100,7 +102,7 @@ class FileField extends BaseField
 				return $name;
 			case 'random':
 				$name = Str::random();
-				
+
 				if ($extention !== null) {
 					$name = sprintf('%s.%s', $name, $extention);
 				}


### PR DESCRIPTION
I got this error when using the file field.

`exception 'Symfony\Component\Debug\Exception\FatalErrorException' with message 'Class 'KraftHaus\Bauhaus\Field\View' not found' in /Users/timbroddin/Sites/sambal/vrtgif/vendor/krafthaus/bauhaus/src/KraftHaus/Bauhaus/Field/FileField.php:92`

This should fix it.
