### PR TITLE
Fixes pagination

### DIFF
--- a/src/KraftHaus/Bauhaus/Builder/ListBuilder.php
+++ b/src/KraftHaus/Bauhaus/Builder/ListBuilder.php
@@ -62,7 +62,7 @@ class ListBuilder extends BaseBuilder
 
 		// Field filters
 		foreach (Input::all() as $key => $value) {
-			if (empty($value) || substr($key, 0, 1) == '_') {
+			if (empty($value) || substr($key, 0, 1) == '_' || $key == 'page') {
 				continue;
 			}
 
@@ -138,7 +138,7 @@ class ListBuilder extends BaseBuilder
 
 	/**
 	 * Set the paginator object.
-	 * 
+	 *
 	 * @param  Paginator $paginator
 	 *
 	 * @access public


### PR DESCRIPTION
There's a problem with the pagination. The GET parameter ?page=x is passed to the filter mechanism.

This is a simple patch that fixes it. It's not the best solution, but it works.
