### PR TITLE
Ability to cast identifier to non-integer type

### DIFF
--- a/src/KraftHaus/Bauhaus/Builder/FormBuilder.php
+++ b/src/KraftHaus/Bauhaus/Builder/FormBuilder.php
@@ -62,6 +62,10 @@ class FormBuilder extends BaseBuilder
 	 */
 	public function getIdentifier()
 	{
+        $model = $this->getModel();
+        if ($this->identifier !== null && method_exists($model, 'castIdentifier')) {
+            $this->identifier = $model::castIdentifier($this->identifier);
+        }
 		return $this->identifier;
 	}
 


### PR DESCRIPTION
I had a problem with mongodb table. In my case primary key had string type and FormBuilder::build failed with error because "$items->where($primaryKey, $this->getIdentifier());" did not return nothing. So, I propose to add to user model castIdentifier method if you need to cast your identifier to non-integer value. test
